### PR TITLE
Update app.py to include setPreviewKeepAspectRatio

### DIFF
--- a/video-stream/app.py
+++ b/video-stream/app.py
@@ -109,6 +109,7 @@ def create_rgb_sensor(pipeline: dai.Pipeline,
     node.setInterleaved(False)
     node.setColorOrder(dai.ColorCameraProperties.ColorOrder.BGR)
     node.setPreviewNumFramesPool(4)
+    node.setPreviewKeepAspectRatio(True) #True: letter-boxing, False: resizing. Resizing recommended for square preview and model.
     node.setPreviewSize(*preview_resolution)
     node.setVideoSize(1920, 1080)
     node.setResolution(resolution)


### PR DESCRIPTION
This could help users who struggle with an incorrect coordinate system after changing their NN model to a square input shape, and therefore also changing their preview to a square shape.
Using setPreviewKeepAspectRatio(False) will enable resizing to happen and fixes the coordinate system for the output.